### PR TITLE
Require isCaseAccessor in isField

### DIFF
--- a/bigquery/src/main/scala/shapeless/datatype/bigquery/BigQuerySchema.scala
+++ b/bigquery/src/main/scala/shapeless/datatype/bigquery/BigQuerySchema.scala
@@ -9,7 +9,7 @@ import scala.reflect.runtime.universe._
 object BigQuerySchema {
 
   private def isField(s: Symbol): Boolean =
-    s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor
+    s.isPublic && s.isMethod && !s.isSynthetic && !s.isConstructor && s.asMethod.isCaseAccessor
 
   private def isCaseClass(tpe: Type): Boolean =
     !tpe.toString.startsWith("scala.") &&


### PR DESCRIPTION
Add `s.asMethod.isCaseAccessor` requirement in `isField` to prevent case class methods from mapping to BQ types. Trying to map a method with a `Unit` return type to a BQ type throws an exception.

This is useful when trying to write ScalaPB generated case class to to BigQuery.