### PR TITLE
Use Iterable instead of Seq for MapRecords (#11)

### DIFF
--- a/core/src/main/scala/shapeless/datatype/record/RecordMapper.scala
+++ b/core/src/main/scala/shapeless/datatype/record/RecordMapper.scala
@@ -38,20 +38,20 @@ trait LowPriorityMapRecordOption1 extends LowPriorityMapRecord1 {
   }
 }
 
-trait LowPriorityMapRecordSeq1 extends LowPriorityMapRecordOption1 {
-  implicit def hconsMapRecordSeq1[K <: Symbol, V, W, TI <: HList, TO <: HList, S[_] <: Seq[_]]
+trait LowPriorityMapRecordIterable1 extends LowPriorityMapRecordOption1 {
+  implicit def hconsMapRecordIterable1[K <: Symbol, V, W, TI <: HList, TO <: HList, S[_] <: Iterable[_]]
   (implicit f: V => W, mrT: Lazy[MapRecord[TI, TO]],
    cbf: CanBuildFrom[_, W, S[W]])
   : MV[K, S[V], S[W], TI, TO] = new MV[K, S[V], S[W], TI, TO] {
     override def apply(l: FieldType[K, S[V]] :: TI): FieldType[K, S[W]] :: TO = {
       val b = cbf()
-      b ++= l.head.asInstanceOf[Seq[V]].map(f)
+      b ++= l.head.asInstanceOf[Iterable[V]].map(f)
       field[K](b.result()) :: mrT.value(l.tail)
     }
   }
 }
 
-trait LowPriorityMapRecord0 extends LowPriorityMapRecordSeq1 {
+trait LowPriorityMapRecord0 extends LowPriorityMapRecordIterable1 {
   implicit def hconsMapRecord0[K <: Symbol, V, W, HV <: HList, HW <: HList, TI <: HList, TO <: HList]
   (implicit genV: LabelledGeneric.Aux[V, HV], genW: LabelledGeneric.Aux[W, HW],
    mrH: Lazy[MapRecord[HV, HW]], mrT: Lazy[MapRecord[TI, TO]])
@@ -71,21 +71,21 @@ trait LowPriorityMapRecordOption0 extends LowPriorityMapRecord0 {
   }
 }
 
-trait LowPriorityMapRecordSeq0 extends LowPriorityMapRecordOption0 {
-  implicit def hconsMapRecordSeq0[K <: Symbol, V, W, HV <: HList, HW <: HList, TI <: HList, TO <: HList, S[_] <: Seq[_]]
+trait LowPriorityMapRecordIterable0 extends LowPriorityMapRecordOption0 {
+  implicit def hconsMapRecordIterable0[K <: Symbol, V, W, HV <: HList, HW <: HList, TI <: HList, TO <: HList, S[_] <: Iterable[_]]
   (implicit genV: LabelledGeneric.Aux[V, HV], genW: LabelledGeneric.Aux[W, HW],
    mrH: Lazy[MapRecord[HV, HW]], mrT: Lazy[MapRecord[TI, TO]],
    cbf: CanBuildFrom[_, W, S[W]])
   : MV[K, S[V], S[W], TI, TO] = new MV[K, S[V], S[W], TI, TO] {
     override def apply(l: FieldType[K, S[V]] :: TI): FieldType[K, S[W]] :: TO = {
       val b = cbf()
-      b ++=  l.head.asInstanceOf[Seq[V]].map(v => genW.from(mrH.value(genV.to(v))))
+      b ++=  l.head.asInstanceOf[Iterable[V]].map(v => genW.from(mrH.value(genV.to(v))))
       field[K](b.result()) :: mrT.value(l.tail)
     }
   }
 }
 
-object MapRecord extends LowPriorityMapRecordSeq0 {
+object MapRecord extends LowPriorityMapRecordIterable0 {
   implicit val hnilMapRecord: MapRecord[HNil, HNil] = new MapRecord[HNil, HNil] {
     override def apply(l: HNil): HNil = l
   }

--- a/core/src/test/scala/shapeless/datatype/record/RecordMapperSpec.scala
+++ b/core/src/test/scala/shapeless/datatype/record/RecordMapperSpec.scala
@@ -12,18 +12,30 @@ object RecordMapperRecords {
   case class RequiredB(intField: Int, longField: Long, stringField: Array[Byte])
   case class OptionalA(intField: Option[Int], longField: Option[Long], stringField: Option[String])
   case class OptionalB(intField: Option[Int], longField: Option[Long], stringField: Option[Array[Byte]])
-  case class RepeatedA(intField: List[Int], longField: List[Long], stringField: List[String])
-  case class RepeatedB(intField: List[Int], longField: List[Long], stringField: List[Array[Byte]])
+  case class RepeatedA(intList: List[Int], longList: List[Long], stringList: List[String],
+                       intSet: Set[Int], longSet: Set[Long], stringSet: Set[String],
+                       intMap: Map[String, Int], longMap: Map[String, Long]/*, stringMap: Map[String, String]*/)
+  case class RepeatedB(intList: List[Int], longList: List[Long], stringList: List[Array[Byte]],
+                       intSet: Set[Int], longSet: Set[Long], stringSet: Set[Array[Byte]],
+                       intMap: Map[String, Int], longMap: Map[String, Long]/*, stringMap: Map[String, Array[Byte]]*/)
   case class MixedA(intField: Int, stringField: String,
                     intFieldO: Option[Int], stringFieldO: Option[String],
-                    intFieldR: List[Int], stringFieldR: List[String])
+                    intList: List[Int], stringList: List[String],
+                    intSet: Set[Int], stringSet: Set[String],
+                    intMap: Map[String, Int]/*, stringMap: Map[String, String]*/)
   case class MixedB(intField: Int, stringField: Array[Byte],
                     intFieldO: Option[Int], stringFieldO: Option[Array[Byte]],
-                    intFieldR: List[Int], stringFieldR: List[Array[Byte]])
-  case class NestedA(required: String, optional: Option[String], repeated: List[String],
-                     requiredN: MixedA, optionalN: Option[MixedA], repeatedN: List[MixedA])
-  case class NestedB(required: Array[Byte], optional: Option[Array[Byte]], repeated: List[Array[Byte]],
-                     requiredN: MixedB, optionalN: Option[MixedB], repeatedN: List[MixedB])
+                    intList: List[Int], stringList: List[Array[Byte]],
+                    intSet: Set[Int], stringSet: Set[Array[Byte]],
+                    intMap: Map[String, Int]/*, stringMap: Map[String, Array[Byte]]*/)
+  case class NestedA(required: String, optional: Option[String],
+                     list: List[String], set: Set[String], map: Map[String, Int],
+                     requiredN: MixedA, optionalN: Option[MixedA],
+                     listN: List[MixedA], setN: Set[MixedA]/*, mapN: Map[String, MixedA]*/)
+  case class NestedB(required: Array[Byte], optional: Option[Array[Byte]],
+                     list: List[Array[Byte]], set: Set[Array[Byte]], map: Map[String, Int],
+                     requiredN: MixedB, optionalN: Option[MixedB],
+                     listN: List[MixedB], setN: Set[MixedB]/*, mapN: Map[String, MixedB]*/)
 }
 
 object RecordMapperSpec extends Properties("RecordMapper") {


### PR DESCRIPTION
`Map`s which need to be mapped via an implicit conversion (e.g. `String => Array[Byte]`), or contain different case classes (even if they share the same structure: e.g. mapping from `Map[String, X]` to `Map[String, Y]` where `X(a: Int)` and `Y(a: Int)`), do not compile.
I've tried to track down the cause, with no success so far. Nevertheless, this is not a problem for me right now, so if you don't mind I'll open a different issue for that.

Closes #11