### PR TITLE
use iterable instead of seq in from and to mappable type class instances

### DIFF
--- a/avro/src/test/scala/shapeless/datatype/avro/AvroTypeSpec.scala
+++ b/avro/src/test/scala/shapeless/datatype/avro/AvroTypeSpec.scala
@@ -71,7 +71,7 @@ object AvroTypeSpec extends Properties("AvroType") {
   property("repeated") = forAll { m: Repeated => roundTrip(m) }
   property("mixed") = forAll { m: Mixed => roundTrip(m) }
   property("nested") = forAll { m: Nested => roundTrip(m) }
-  property("seqs") = forAll { m: Seqs => roundTrip(m) }
+  property("iterables") = forAll { m: Iterables => roundTrip(m) }
 
   implicit val uriAvroType = AvroType.at[URI](Schema.Type.STRING)(
     v => URI.create(v.toString), _.toString)

--- a/bigquery/src/test/scala/shapeless/datatype/bigquery/BigQueryTypeSpec.scala
+++ b/bigquery/src/test/scala/shapeless/datatype/bigquery/BigQueryTypeSpec.scala
@@ -56,7 +56,7 @@ object BigQueryTypeSpec extends Properties("BigQueryType") {
   property("repeated") = forAll { m: Repeated => roundTrip(m) }
   property("mixed") = forAll { m: Mixed => roundTrip(m) }
   property("nested") = forAll { m: Nested => roundTrip(m) }
-  property("seqs") = forAll { m: Seqs => roundTrip(m) }
+  property("iterables") = forAll { m: Iterables => roundTrip(m) }
 
   implicit val arbDate = Arbitrary(arbInstant.arbitrary.map(i => new LocalDate(i.getMillis)))
   implicit val arbTime = Arbitrary(arbInstant.arbitrary.map(i => new LocalTime(i.getMillis)))

--- a/core/src/main/scala/shapeless/datatype/mappable/FromMappable.scala
+++ b/core/src/main/scala/shapeless/datatype/mappable/FromMappable.scala
@@ -28,6 +28,7 @@ trait SerializableCanBuildFrom {
   implicit def indexedSeqCB[T] = newCB(() => IndexedSeq.newBuilder[T])
   implicit def listCB[T] = newCB(() => List.newBuilder[T])
   implicit def vectorCB[T] = newCB(() => Vector.newBuilder[T])
+  implicit def setCB[T] = newCB(() => Set.newBuilder[T])
 }
 
 trait LowPriorityFromMappable1 extends SerializableCanBuildFrom {
@@ -51,10 +52,10 @@ trait LowPriorityFromMappableOption1 extends LowPriorityFromMappable1 {
   }
 }
 
-trait LowPriorityFromMappableSeq1 extends LowPriorityFromMappableOption1 {
-  implicit def hconsFromMappableSeq1[K <: Symbol, V, T <: HList, M, S[_]]
+trait LowPriorityFromMappableIterable1 extends LowPriorityFromMappableOption1 {
+  implicit def hconsFromMappableIterable1[K <: Symbol, V, T <: HList, M, S[_] <: Iterable[_]]
   (implicit wit: Witness.Aux[K], mt: MappableType[M, V], fromT: Lazy[FromMappable[T, M]],
-   cbf: CanBuild[V, S[V]], toSeq: S[V] => Seq[V])
+   cbf: CanBuild[V, S[V]], toIterable: S[V] => Iterable[V])
   : FromMappable[FieldType[K, S[V]] :: T, M] = new FromMappable[FieldType[K, S[V]] :: T, M] {
     override def apply(m: M): Option[FieldType[K, S[V]] :: T] = for {
       t <- fromT.value(m)
@@ -66,7 +67,7 @@ trait LowPriorityFromMappableSeq1 extends LowPriorityFromMappableOption1 {
   }
 }
 
-trait LowPriorityFromMappable0 extends LowPriorityFromMappableSeq1 {
+trait LowPriorityFromMappable0 extends LowPriorityFromMappableIterable1 {
   implicit def hconsFromMappable0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest]
   (implicit wit: Witness.Aux[K], gen: LabelledGeneric.Aux[V, H], bmt: BaseMappableType[M],
    fromH: Lazy[FromMappable[H, M]], fromT: Lazy[FromMappable[T, M]])
@@ -96,11 +97,11 @@ trait LowPriorityFromMappableOption0 extends LowPriorityFromMappable0 {
   }
 }
 
-trait LowPriorityFromMappableSeq0 extends LowPriorityFromMappableOption0 {
-  implicit def hconsFromMappableSeq0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest, S[_]]
+trait LowPriorityFromMappableIterable0 extends LowPriorityFromMappableOption0 {
+  implicit def hconsFromMappableIterable0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest, S[_] <: Iterable[_]]
   (implicit wit: Witness.Aux[K], gen: LabelledGeneric.Aux[V, H], bmt: BaseMappableType[M],
    fromH: Lazy[FromMappable[H, M]], fromT: Lazy[FromMappable[T, M]],
-   cbf: CanBuild[V, S[V]], toSeq: S[V] => Seq[V])
+   cbf: CanBuild[V, S[V]], toIterable: S[V] => Iterable[V])
   : FromMappable[FieldType[K, S[V]] :: T, M] = new FromMappable[FieldType[K, S[V]] :: T, M] {
     override def apply(m: M): Option[FieldType[K, S[V]] :: T] = for {
       t <- fromT.value(m)
@@ -115,7 +116,7 @@ trait LowPriorityFromMappableSeq0 extends LowPriorityFromMappableOption0 {
   }
 }
 
-object FromMappable extends LowPriorityFromMappableSeq0 {
+object FromMappable extends LowPriorityFromMappableIterable0 {
   implicit def hnilFromMappable[M]: FromMappable[HNil, M] = new FromMappable[HNil, M] {
     override def apply(m: M): Option[HNil] = Some(HNil)
   }

--- a/core/src/main/scala/shapeless/datatype/mappable/ToMappable.scala
+++ b/core/src/main/scala/shapeless/datatype/mappable/ToMappable.scala
@@ -27,17 +27,17 @@ trait LowPriorityToMappableOption1 extends LowPriorityToMappable1 {
   }
 }
 
-trait LowPriorityToMappableSeq1 extends LowPriorityToMappableOption1 {
-  implicit def hconsToMappableSeq1[K <: Symbol, V, T <: HList, M, S[_]]
+trait LowPriorityToMappableIterable1 extends LowPriorityToMappableOption1 {
+  implicit def hconsToMappableIterable1[K <: Symbol, V, T <: HList, M, S[_] <: Iterable[_]]
   (implicit wit: Witness.Aux[K], mt: MappableType[M, V], toT: Lazy[ToMappable[T, M]],
-   toSeq: S[V] => Seq[V])
+   toIterable: S[V] => Iterable[V])
   : ToMappable[FieldType[K, S[V]] :: T, M] = new ToMappable[FieldType[K, S[V]] :: T, M] {
     override def apply(l: FieldType[K, S[V]] :: T): M =
-      mt.put(wit.value.name, toSeq(l.head), toT.value(l.tail))
+      mt.put(wit.value.name, toIterable(l.head).toSeq, toT.value(l.tail))
   }
 }
 
-trait LowPriorityToMappable0 extends LowPriorityToMappableSeq1 {
+trait LowPriorityToMappable0 extends LowPriorityToMappableIterable1 {
   implicit def hconsToMappable0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest]
   (implicit wit: Witness.Aux[K], gen: LabelledGeneric.Aux[V, H], mbt: BaseMappableType[M],
    toH: Lazy[ToMappable[H, M]], toT: Lazy[ToMappable[T, M]])
@@ -57,18 +57,18 @@ trait LowPriorityToMappableOption0 extends LowPriorityToMappable0 {
   }
 }
 
-trait LowPriorityToMappableSeq0 extends LowPriorityToMappableOption0 {
-  implicit def hconsToMappableSeq0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest, S[_]]
+trait LowPriorityToMappableIterable0 extends LowPriorityToMappableOption0 {
+  implicit def hconsToMappableIterable0[K <: Symbol, V, H <: HList, T <: HList, M: CanNest, S[_] <: Iterable[_]]
   (implicit wit: Witness.Aux[K], gen: LabelledGeneric.Aux[V, H], mbt: BaseMappableType[M],
    toH: Lazy[ToMappable[H, M]], toT: Lazy[ToMappable[T, M]],
-   toSeq: S[V] => Seq[V])
+   toIterable: S[V] => Iterable[V])
   : ToMappable[FieldType[K, S[V]] :: T, M] = new ToMappable[FieldType[K, S[V]] :: T, M] {
     override def apply(l: FieldType[K, S[V]] :: T): M =
-      mbt.put(wit.value.name, toSeq(l.head).map(h => toH.value(gen.to(h))), toT.value(l.tail))
+      mbt.put(wit.value.name, toIterable(l.head).toSeq.map(h => toH.value(gen.to(h))), toT.value(l.tail))
   }
 }
 
-object ToMappable extends LowPriorityToMappableSeq0 {
+object ToMappable extends LowPriorityToMappableIterable0 {
   implicit def hnilToMappable[M](implicit mbt: BaseMappableType[M])
   : ToMappable[HNil, M] = new ToMappable[HNil, M] {
     override def apply(l: HNil): M = mbt.base

--- a/datastore/src/test/scala/shapeless/datatype/datastore/DatastoreTypeSpec.scala
+++ b/datastore/src/test/scala/shapeless/datatype/datastore/DatastoreTypeSpec.scala
@@ -58,7 +58,7 @@ object DatastoreTypeSpec extends Properties("DatastoreType") {
   property("repeated") = forAll { m: Repeated => roundTrip(m) }
   property("mixed") = forAll { m: Mixed => roundTrip(m) }
   property("nested") = forAll { m: Nested => roundTrip(m) }
-  property("seqs") = forAll { m: Seqs => roundTrip(m) }
+  property("iterables") = forAll { m: Iterables => roundTrip(m) }
 
   implicit val uriDatastoreType = DatastoreType.at[URI](
     v => URI.create(v.getStringValue), u => makeValue(u.toString).build())

--- a/tensorflow/src/test/scala/shapeless/datatype/tensorflow/TensorFlowTypeSpec.scala
+++ b/tensorflow/src/test/scala/shapeless/datatype/tensorflow/TensorFlowTypeSpec.scala
@@ -61,7 +61,7 @@ object TensorFlowTypeSpec extends Properties("TensorFlowType") {
   property("optional") = forAll { m: Optional => roundTrip(m) }
   property("repeated") = forAll { m: Repeated => roundTrip(m) }
   property("mixed") = forAll { m: Mixed => roundTrip(m) }
-  property("seqs") = forAll { m: Seqs => roundTrip(m) }
+  property("iterables") = forAll { m: Iterables => roundTrip(m) }
 
   implicit val uriTensorFlowType = TensorFlowType.at[URI](
     TensorFlowType.toStrings(_).map(URI.create),

--- a/test/src/test/scala/shapeless/datatype/test/Records.scala
+++ b/test/src/test/scala/shapeless/datatype/test/Records.scala
@@ -29,7 +29,7 @@ object Records {
                    longFieldR: List[Long], doubleFieldR: List[Double], stringFieldR: List[String])
   case class Nested(longField: Long, longFieldO: Option[Long], longFieldR: List[Long],
                     mixedField: Mixed, mixedFieldO: Option[Mixed], mixedFieldR: List[Mixed])
-  case class Seqs(array: Array[Int], list: List[Int], vector: Vector[Int])
+  case class Iterables(/*array: Array[Int], */list: List[Int], vector: Vector[Int], set: Set[Int])
   case class Custom(uriField: URI, uriFieldO: Option[URI], uriFieldR: List[URI])
 
   implicit val arbByteString = Arbitrary(Gen.alphaStr.map(ByteString.copyFromUtf8))


### PR DESCRIPTION
Closes #40 

This isn't ready yet since I can't get the tests to compile without having that array field commented out, so do not merge. Opening this to see if there any suggestions as to why this is happening.