### PR TITLE
Update datastore-v1-proto-client to 3.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ description := "Shapeless utilities for common data types"
 
 val avroVersion = "1.12.2"
 val bigqueryVersion = "v2-rev20260731-2.0.0"
-val datastoreVersion = "3.2.0"
+val datastoreVersion = "3.3.0"
 val jacksonVersion = "2.22.2"
 val jodaTimeVersion = "2.14.3"
 val magnolifyVersion = "0.9.6"


### PR DESCRIPTION
Updates `com.google.cloud.datastore:datastore-v1-proto-client` from 3.2.0 to 3.3.0.

The earlier CI failure in #879 was caused by a Maven Central publication race: the client POM was available before three referenced artifacts. Those artifacts are now available and the update resolves successfully.

Tested with:

```text
sbt "+datastore/testOnly shapeless.datatype.datastore.DatastoreTypeSpec"
```

Both Scala 2.12 and 2.13 passed all 7 properties.

Replaces #879.